### PR TITLE
Feature/#42/20210206 helpful error message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ ujson = "^3.0.0"
 toolz = "^0.10.0"
 networkx = "^2.4"
 matplotlib = "^3.3.0"
+loguru = "^0.5.3"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
Added a dump of the entry giving the error, as well as more detailed error message (which may be scary)
should be more helpful in giving a hint on what is resulting in an error in future

```
Fetching from https://politikus.sinarproject.org/@search?portal_type=Relationship&fullobjects=1&b_start=0
Fetching from https://politikus.sinarproject.org/@search?portal_type=Relationship&fullobjects=1&b_start=25
Fetching from https://politikus.sinarproject.org/@search?portal_type=Relationship&fullobjects=1&b_start=50
2021-02-06 17:46:50.191 | ERROR    | popit_relationship.sync:node_build:336 - 'NoneType' object is not subscriptable
Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/primport.py", line 135, in main
    loop.run_until_complete(app())
    │    │                  └ <Group app>
    │    └ <function BaseEventLoop.run_until_complete at 0x7f9ef251a700>
    └ <_UnixSelectorEventLoop running=False closed=False debug=False>

  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
           │    │     │       └ {}
           │    │     └ ()
           │    └ <function BaseCommand.main at 0x7f9ef2401dc0>
           └ <Group app>
  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
         │    │      └ <click.core.Context object at 0x7f9ee1d0ad90>
         │    └ <function MultiCommand.invoke at 0x7f9ef2404b80>
         └ <Group app>
  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │       │       │      └ <click.core.Context object at 0x7f9ee1d0aee0>
           │               │       │       └ <function MultiCommand.invoke at 0x7f9ef2404b80>
           │               │       └ <Group sync>
           │               └ <click.core.Context object at 0x7f9ee1d0aee0>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7f9ee1d31040>
  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │       │       │      └ <click.core.Context object at 0x7f9ee1d0af40>
           │               │       │       └ <function Command.invoke at 0x7f9ef2404790>
           │               │       └ <Command rel>
           │               └ <click.core.Context object at 0x7f9ee1d0af40>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7f9ee1d311f0>
  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │   │      │    │           │   └ {}
           │   │      │    │           └ <click.core.Context object at 0x7f9ee1d0af40>
           │   │      │    └ <function relationship at 0x7f9ee1d25160>
           │   │      └ <Command rel>
           │   └ <function Context.invoke at 0x7f9ef24018b0>
           └ <click.core.Context object at 0x7f9ee1d0af40>
  File "/home/jeffrey04/.cache/pypoetry/virtualenvs/popit-relationship-tURcevQc-py3.9/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
           │         │       └ {}
           │         └ ()
           └ <function relationship at 0x7f9ee1d25160>

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/common.py", line 16, in wrapper
    return asyncio.run(f(*args, **kwargs))
           │       │   │  │       └ {}
           │       │   │  └ ()
           │       │   └ <function relationship at 0x7f9ee1d250d0>
           │       └ <function run at 0x7f9ef2bb05e0>
           └ <module 'asyncio' from '/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/__init__.py'>

  File "/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
           │    │                  └ <coroutine object relationship at 0x7f9ee1d54740>
           │    └ <function BaseEventLoop.run_until_complete at 0x7f9ef251a700>
           └ <_UnixSelectorEventLoop running=True closed=False debug=False>
  File "/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
    │    └ <function BaseEventLoop.run_forever at 0x7f9ef251a670>
    └ <_UnixSelectorEventLoop running=True closed=False debug=False>
  File "/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
    │    └ <function BaseEventLoop._run_once at 0x7f9ef251e1f0>
    └ <_UnixSelectorEventLoop running=True closed=False debug=False>
  File "/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/base_events.py", line 1890, in _run_once
    handle._run()
    │      └ <function Handle._run at 0x7f9ef2538ca0>
    └ <Handle <TaskWakeupMethWrapper object at 0x7f9ee2d2bb50>(<Future finished result=None>)>
  File "/home/jeffrey04/.pyenv/versions/3.9-dev/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
    │    │            │    │           │    └ <member '_args' of 'Handle' objects>
    │    │            │    │           └ <Handle <TaskWakeupMethWrapper object at 0x7f9ee2d2bb50>(<Future finished result=None>)>
    │    │            │    └ <member '_callback' of 'Handle' objects>
    │    │            └ <Handle <TaskWakeupMethWrapper object at 0x7f9ee2d2bb50>(<Future finished result=None>)>
    │    └ <member '_context' of 'Handle' objects>
    └ <Handle <TaskWakeupMethWrapper object at 0x7f9ee2d2bb50>(<Future finished result=None>)>

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/sync.py", line 218, in relationship
    await tree_import(TYPE_RELATIONSHIP, "Relationship", relationship_build_node)
          │           │                                  └ <function relationship_build_node at 0x7f9ee1d25040>
          │           └ 'http://purl.org/vocab/relationship/Relationship'
          └ <function tree_import at 0x7f9ee1d25940>

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/sync.py", line 393, in tree_import
    tree_insert(graph, **await tree_build(portal_type, node_builder, session))
    │           │              │          │            │             └ <aiohttp.client.ClientSession object at 0x7f9ee1d38370>
    │           │              │          │            └ <function relationship_build_node at 0x7f9ee1d25040>
    │           │              │          └ 'Relationship'
    │           │              └ <function tree_build at 0x7f9ee1d258b0>
    │           └ <networkx.classes.multidigraph.MultiDiGraph object at 0x7f9ee1d384c0>
    └ <function tree_insert at 0x7f9ee1d259d0>

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/sync.py", line 382, in tree_build
    await node_build(node_builder, portal_type, session),
          │          │             │            └ <aiohttp.client.ClientSession object at 0x7f9ee1d38370>
          │          │             └ 'Relationship'
          │          └ <function relationship_build_node at 0x7f9ee1d25040>
          └ <function node_build at 0x7f9ee1d255e0>

> File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/sync.py", line 331, in node_build
    result.append(node_builder(entity))
    │      │      │            └ {'@components': {'actions': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@actions'}, 'breadcrumbs'...
    │      │      └ <function relationship_build_node at 0x7f9ee1d25040>
    │      └ <method 'append' of 'list' objects>
    └ [(None, [{'subject': 'https://politikus.sinarproject.org/persons/khadijah-mohd-noor', 'predicate': {'key': 'http://purl.org/v...

  File "/home/jeffrey04/Projects/popit_relationship/src/popit_relationship/sync.py", line 233, in relationship_build_node
    "object": relationship["relationship_object"]["@id"],
              └ {'@components': {'actions': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@actions'}, 'breadcrumbs'...

TypeError: 'NoneType' object is not subscriptable
2021-02-06 17:46:50.198 | ERROR    | popit_relationship.sync:node_build:337 - The following entity does not have all required fileds:
{'@components': {'actions': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@actions'},
                 'breadcrumbs': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@breadcrumbs'},
                 'navigation': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@navigation'},
                 'types': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@types'},
                 'workflow': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother/@workflow'}},
 '@id': 'https://politikus.sinarproject.org/persons/jalilah-baba/mother',
 '@type': 'Relationship',
 'UID': 'ba92bdbb03aa4000a5facf972cb7fb0a',
 'allow_discussion': False,
 'contributors': [],
 'created': '2021-01-31T21:53:25+00:00',
 'creators': ['chungisad'],
 'description': None,
 'effective': '2021-01-31T21:53:45',
 'end_date': None,
 'exclude_from_nav': False,
 'expires': None,
 'id': 'mother',
 'is_folderish': True,
 'language': {'title': 'English (United Kingdom)', 'token': 'en-gb'},
 'layout': 'relationship-view',
 'modified': '2021-01-31T21:53:45+00:00',
 'name': 'Mother',
 'next_item': {},
 'notes': None,
 'parent': {'@id': 'https://politikus.sinarproject.org/persons/jalilah-baba',
            '@type': 'Person',
            'description': 'Jalilah Baba is the Chairman of PKT Logistics '
                           'Group Sdn Bhd and Crewstone International. She was '
                           'previously the Director of Malaysia Investment '
                           'Development Authority (MIDA) until she retired '
                           'from public service on 20 Ogos 2011.',
            'review_state': 'published',
            'title': 'Jalilah Baba'},
 'previous_item': {},
 'relationship_object': None,
 'relationship_subject': {'@id': 'https://politikus.sinarproject.org/persons/ahmad-izmir-mujab',
                          '@type': 'Person',
                          'description': 'Ahmad Izmir Mujab is the CEO of '
                                         'Crewstone International.',
                          'review_state': 'published',
                          'title': 'Ahmad Izmir Mujab'},
 'relationship_type': {'title': 'Parent', 'token': 'parent'},
 'review_state': 'published',
 'rights': None,
 'start_date': None,
 'subjects': [],
 'version': 'current'}
```